### PR TITLE
Add function to generate rootpath entry for user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The goal is to keep the repository size small (~ 100 MB), so it can be easily do
 
 At present, the repository contains 44 monthly, and 35 daily timeseries datasets. The specifications can be found in [`datasets.yml`](esmvaltool_sample_data/datasets.yml).
 
+The data are stored using the data reference syntax structure from DKRZ.
+
 ## Usage
 
 The functionality of this repository is kept simple.
@@ -31,7 +33,7 @@ rootpath:
     - <path_to_repository>/esmvaltool_sample_data/data/timeseries/CMIP6
 
 drs:
-  CMIP6: default
+  CMIP6: DKRZ
 ```
 
 If you have installed `esmvaltool_sample_data`, you can find the `rootpath` settings using `python -c 'import esmvaltool_sample_data, yaml; print(yaml.dump(esmvaltool_sample_data.get_rootpaths()))'`

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ If you want to use this dataset in your ESMValTool projects, add the following l
 
 ```yaml
 rootpath:
-  CMIP6: <path_to_repository>/esmvaltool_sample_data/data/timeseries/
+  CMIP6:
+  - <path_to_repository>/esmvaltool_sample_data/data/timeseries/CMIP6
 
 drs:
   CMIP6: default
 ```
 
-If you have installed `esmvaltool_sample_data`, you can find the `rootpath` using `python -c 'from esmvaltool_sample_data import base_dir; print(base_dir.parent)'`
+If you have installed `esmvaltool_sample_data`, you can find the `rootpath` using `python -c 'import esmvaltool_sample_data, yaml; print(yaml.dump(esmvaltool_sample_data.get_rootpaths()))'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ drs:
   CMIP6: default
 ```
 
-If you have installed `esmvaltool_sample_data`, you can find the `rootpath` using `python -c 'import esmvaltool_sample_data, yaml; print(yaml.dump(esmvaltool_sample_data.get_rootpaths()))'`
+If you have installed `esmvaltool_sample_data`, you can find the `rootpath` settings using `python -c 'import esmvaltool_sample_data, yaml; print(yaml.dump(esmvaltool_sample_data.get_rootpaths()))'`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to use this dataset in your ESMValTool projects, add the following l
 ```yaml
 rootpath:
   CMIP6:
-  - <path_to_repository>/esmvaltool_sample_data/data/timeseries/CMIP6
+    - <path_to_repository>/esmvaltool_sample_data/data/timeseries/CMIP6
 
 drs:
   CMIP6: default

--- a/esmvaltool_sample_data/__init__.py
+++ b/esmvaltool_sample_data/__init__.py
@@ -7,7 +7,9 @@ base_dir = Path(__file__).parent
 
 VERBOSE = False
 
-# This ignore list is used to help with debugging
+# This ignore list is used to help with debugging only
+# for a more permanent solution, add
+# problematic datasets the `ignore` section in `../datasets.yml`.
 ignore_list = [
     # 'CMIP6/CMIP/AWI/AWI-ESM-1-1-LR/historical/r1i1p1f1/Amon/ta/gn/v20200212',
 ]
@@ -50,6 +52,7 @@ def load_cubes_from_input_dirs(input_dirs: list) -> 'iris.Cube':
 
 
 def filter_ignored_datasets(dirs, root):
+    """Filter datasets defined in the global `ignore` list."""
     for drc in dirs:
         test_drc = str(drc.relative_to(root))
         if test_drc not in ignore_list:
@@ -85,6 +88,22 @@ def load_timeseries_cubes(mip_table: str = 'Amon') -> list:
     cubes = load_cubes_from_input_dirs(input_dirs)
 
     return list(cubes)
+
+
+def get_rootpaths() -> dict:
+    """Return a dict with rootpaths to update the user config in ESMValTool."""
+    rootpath = {
+        'rootpath': {
+            'CMIP6': [
+                str(base_dir / 'data' / 'timeseries' / 'CMIP6'),
+            ]
+        },
+        'drs': {
+            'CMIP6': 'default',
+        },
+    }
+
+    return rootpath
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a function to get the rootpath structure for the user config.
This is needed for https://github.com/ESMValGroup/ESMValCore/pull/907

```python
In [1]: from esmvaltool_sample_data import get_rootpaths
In [2]: get_rootpaths()
Out[2]:
{'rootpath': {'CMIP6': ['/home/stef/r/esmvaltool_sample_data/esmvaltool_sample_data/data/timeseries/CMIP6']},
 'drs': {'CMIP6': 'default'}}
```