### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ PACKAGES = [
 
 setup(
     name='ESMValTool sample data',
-    version='0.0.1',
+    version='0.0.3',
     description="ESMValTool sample data",
     long_description=readme + '\n\n',
     author="Stef Smeets, Bouwe Andela",


### PR DESCRIPTION
I forgot to bump the version number in setup.py in the last PR, and I think that causes CircleCI to not update the old version in ESMValCore.